### PR TITLE
Replace deprecated methods. Add license file.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+The MIT License (MIT)
+=====================
+
+Copyright © 2014-2025 by Wolf Rentzsch
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/NSKeyedArchiver+butWithNSError/NSKeyedArchiver+butWithNSError.m
+++ b/NSKeyedArchiver+butWithNSError/NSKeyedArchiver+butWithNSError.m
@@ -15,9 +15,7 @@
 #if !__has_feature(objc_arc)
     [archiver autorelease];
 #endif
-    if (requiresSecureCoding) {
-        archiver.requiresSecureCoding = YES;
-    }
+    
     @try {
         [archiver encodeObject:rootObject forKey:NSKeyedArchiveRootObjectKey];
         [archiver finishEncoding];
@@ -45,8 +43,10 @@
 #if !__has_feature(objc_arc)
     [unarchiver autorelease];
 #endif
-    if (requiresSecureCoding) {
-        unarchiver.requiresSecureCoding = YES;
+    unarchiver.requiresSecureCoding = requiresSecureCoding;
+
+    if (*error != nil) {
+        return nil;
     }
     
     @try {
@@ -71,6 +71,7 @@
         id result = [unarchiver decodeObjectOfClasses:classWhitelist
                                                forKey:NSKeyedArchiveRootObjectKey];
         [unarchiver finishDecoding];
+        *error = unarchiver.error;
         return result;
     } @catch(NSException *exception) {
         if (error) {

--- a/NSKeyedArchiver+butWithNSError/NSKeyedArchiver+butWithNSError.m
+++ b/NSKeyedArchiver+butWithNSError/NSKeyedArchiver+butWithNSError.m
@@ -11,8 +11,7 @@
                     requiresSecureCoding:(BOOL)requiresSecureCoding
                                    error:(NSError**)error
 {
-    NSMutableData *result = [NSMutableData data];
-    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:result];
+    NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:requiresSecureCoding];
 #if !__has_feature(objc_arc)
     [archiver autorelease];
 #endif
@@ -22,7 +21,7 @@
     @try {
         [archiver encodeObject:rootObject forKey:NSKeyedArchiveRootObjectKey];
         [archiver finishEncoding];
-        return result;
+        return [archiver encodedData];
     } @catch (NSException *exception) {
         if (error) {
             *error = [NSError errorWithDomain:NSInvalidArchiveOperationException
@@ -42,7 +41,7 @@
              whitelist:(NSArray*)customClassWhitelist
                  error:(NSError**)error
 {
-    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:error];
 #if !__has_feature(objc_arc)
     [unarchiver autorelease];
 #endif

--- a/Tests/NSKeyedArchiver+butWithNSErrorTest.xcodeproj/project.pbxproj
+++ b/Tests/NSKeyedArchiver+butWithNSErrorTest.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -404,6 +405,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "NSKeyedArchiver+butWithNSErrorTest/NSKeyedArchiver+butWithNSErrorTest-Prefix.pch";
 				INFOPLIST_FILE = "NSKeyedArchiver+butWithNSErrorTest/NSKeyedArchiver+butWithNSErrorTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -417,6 +419,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "NSKeyedArchiver+butWithNSErrorTest/NSKeyedArchiver+butWithNSErrorTest-Prefix.pch";
 				INFOPLIST_FILE = "NSKeyedArchiver+butWithNSErrorTest/NSKeyedArchiver+butWithNSErrorTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -438,6 +441,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "NSKeyedArchiver+butWithNSErrorTestTests/NSKeyedArchiver+butWithNSErrorTestTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -456,6 +460,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "NSKeyedArchiver+butWithNSErrorTest/NSKeyedArchiver+butWithNSErrorTest-Prefix.pch";
 				INFOPLIST_FILE = "NSKeyedArchiver+butWithNSErrorTestTests/NSKeyedArchiver+butWithNSErrorTestTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/Tests/NSKeyedArchiver+butWithNSErrorTestTests/NSKeyedArchiver_butWithNSErrorTestTests.m
+++ b/Tests/NSKeyedArchiver+butWithNSErrorTestTests/NSKeyedArchiver_butWithNSErrorTestTests.m
@@ -122,7 +122,8 @@ static void testEverySecureEncodeDecodeCombination(SecureEncodeDecodeBlock block
                                                                                                  error:&error];
                 XCTAssertNil(decodedObject, @"");
                 XCTAssertNotNil(error, @"");
-                XCTAssertEqualObjects(error.domain, NSInvalidUnarchiveOperationException, @"");
+                XCTAssertEqualObjects(error.domain, NSCocoaErrorDomain, @"");
+                XCTAssertTrue([[error.userInfo objectForKey:NSDebugDescriptionErrorKey] hasPrefix:@"value for key 'root' was of unexpected class 'MyClassConformingToNSSecureCoding'"]);
             }}
             {{
                 // Ensure decoding succeeds if we whitelist our custom class.


### PR DESCRIPTION
The following initialization methods were deprecated in macOS 10.14 and replaced with the indicated methods:

* `initForWritingWithMutableData:` in `NSKeyedArchiver` replaced with `initRequiringSecureCoding`
* `initForReadingWithData:` for NSKeyedUnarchiver replaced with `initForReadingWithData:error:`

Oh, and a license file as requested in #1.

### Explanation

I know this is old code. However, I was working on some old code, couldn't get the archive/unarchive thing to properly work with non-deprecated methods, found this lovely library, changed the methods that needed changing, and — _et voilà!_ — it works!

So, here's the code that doesn't get all XCode complainy. 

**Thank you very much for initially sorting it out.**